### PR TITLE
enhance: add metadata oauth to gitlab-example-tool

### DIFF
--- a/tool.gpt
+++ b/tool.gpt
@@ -11,3 +11,7 @@ GitLab
 ---
 !metadata:*:icon
 https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/gitlab-logo-duotone.svg
+
+---
+!metadata:*:oauth
+gitlab


### PR DESCRIPTION
* add metadata for oauth to the gitlab-example-tool (needed for docs Integrating OAuth guide)